### PR TITLE
Update node engine to 6

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "bugs": "http://github.com/driverdan/node-XMLHttpRequest/issues",
   "engines": {
-    "node": ">=0.4.0"
+    "node": ">=6"
   },
   "directories": {
     "lib": "./lib",


### PR DESCRIPTION
0.X makes no sense anyways. Version 6 seems to run fine